### PR TITLE
Adds new testcontainers-desktop cask

### DIFF
--- a/Casks/testcontainers-desktop.rb
+++ b/Casks/testcontainers-desktop.rb
@@ -1,0 +1,41 @@
+cask "testcontainers-desktop" do
+  version ""
+  sha256 ""
+
+  url "https://app.testcontainers.cloud/download/testcontainers-desktop_#{version}_darwin_universal.dmg",
+      user_agent: "brew-cask"
+  name "Testcontainers Desktop"
+  desc "Tescontainers desktop application for local testing and development"
+  homepage "https://app.testcontainers.cloud/"
+
+  conflicts_with cask: "testcontainers-cloud-desktop"
+
+  livecheck do
+    url "https://app.testcontainers.cloud/api/versions"
+    strategy :page_match do |page|
+      JSON.parse(page)["latest"]
+    end
+  end
+
+  app "Testcontainers Desktop.app"
+
+  postflight do
+    system_command "open",
+                   args: ["#{appdir}/Testcontainers Desktop.app"]
+  end
+
+  uninstall delete: [
+              "~/Library/Caches/AtomicJar",
+            ],
+            quit:   [
+              "com.atomicjar.desktop",
+            ]
+
+  zap trash:  [
+        "~/.config/testcontainers",
+        "~/Library/Logs/AtomicJar",
+      ],
+      delete: [
+        "~/Library/LaunchAgents/testcontainers.desktop.plist",
+      ]
+end


### PR DESCRIPTION
* version and hash originally blank so we can check and use livecheck
* conflicts with old/deprecated cask to encourage users to uninstall as old cask will no longer receive updates.

Part of the https://github.com/AtomicJar/testcontainers-cloud-client/issues/585