### PR TITLE
Print BIG warning if a user upgrades or install the old cask.

### DIFF
--- a/Casks/testcontainers-cloud-desktop.rb
+++ b/Casks/testcontainers-cloud-desktop.rb
@@ -22,6 +22,21 @@ cask "testcontainers-cloud-desktop" do
                    args: ["#{appdir}/Testcontainers Cloud Desktop.app"]
   end
 
+  caveats "
+  ******** WARNING *******
+  #{token} will no longer receive updates.
+
+  Please use testcontainers-desktop instead for a more fully-featured desktop experience!
+
+  Please run:
+
+  brew uninstall #{token}
+  brew install testcontainers-desktop
+
+  ******** WARNING *******
+
+  "
+
   uninstall delete: [
               "~/Library/Caches/AtomicJar",
             ],


### PR DESCRIPTION
Note: if users are on the latest version they are unlikley to see this warning.

We could one of:
1. Publish noop upgrades
2. Publish a upgrade that break install on purpose

To make these warnings more visible and encourage migration.