### PR TITLE
Don't cleanup cache folder every upgrade

### DIFF
--- a/Casks/testcontainers-cloud-desktop.rb
+++ b/Casks/testcontainers-cloud-desktop.rb
@@ -38,15 +38,18 @@ cask "testcontainers-cloud-desktop" do
   "
 
   uninstall delete: [
-              "~/Library/Caches/AtomicJar",
+              "~/Library/Caches/AtomicJar/testcontainers.cloud.desktop/agent.lock",
+              "~/Library/Caches/AtomicJar/testcontainers.cloud.desktop/tcc-notification.png",
             ],
             quit:   [
               "com.atomicjar.cloud.desktop",
             ]
 
   zap trash:  [
-        "~/.config/testcontainers",
+        "~/.config/testcontainers/services",
+        "~/.config/testcontainers/cloud.properties",
         "~/Library/Application Support/testcontainers.cloud.desktop",
+        "~/Library/Caches/AtomicJar",
         "~/Library/Logs/AtomicJar",
       ],
       delete: [

--- a/Casks/testcontainers-desktop.rb
+++ b/Casks/testcontainers-desktop.rb
@@ -24,15 +24,18 @@ cask "testcontainers-desktop" do
                    args: ["#{appdir}/Testcontainers Desktop.app"]
   end
 
-  uninstall delete: [
-              "~/Library/Caches/AtomicJar",
+ uninstall delete: [
+              "~/Library/Caches/AtomicJar/testcontainers.cloud.desktop/agent.lock",
+              "~/Library/Caches/AtomicJar/testcontainers.cloud.desktop/tcc-notification.png",
             ],
             quit:   [
               "com.atomicjar.desktop",
             ]
 
   zap trash:  [
-        "~/.config/testcontainers",
+        "~/.config/testcontainers/services",
+        "~/.config/testcontainers/cloud.properties",
+        "~/Library/Caches/AtomicJar",
         "~/Library/Logs/AtomicJar",
       ],
       delete: [


### PR DESCRIPTION
This should help with the installation id being cleaned up every upgrade