### PR TITLE
Indicates the app can self update

### DIFF
--- a/Casks/testcontainers-desktop.rb
+++ b/Casks/testcontainers-desktop.rb
@@ -15,6 +15,7 @@ cask "testcontainers-desktop" do
     end
   end
 
+  auto_updates true
   conflicts_with cask: "testcontainers-cloud-desktop"
 
   app "Testcontainers Desktop.app"


### PR DESCRIPTION
Per [cask cookbook](https://docs.brew.sh/Cask-Cookbook)

> true. Asserts that the cask artifacts auto-update. Use if Check for Updates… or similar is present in an app menu, but not if it only opens a webpage and does not do the download and installation for you.